### PR TITLE
Provide matchMedia implementation

### DIFF
--- a/src/tamagui.config.ts
+++ b/src/tamagui.config.ts
@@ -2,6 +2,7 @@ import { createInterFont } from "@tamagui/font-inter";
 import { shorthands } from "@tamagui/shorthands";
 import { themes, tokens } from "@tamagui/theme-base";
 import { createTamagui } from "tamagui";
+import { createMedia } from '@tamagui/react-native-media-driver'
 
 import { animations } from "./constants/animations";
 
@@ -61,7 +62,7 @@ const config = createTamagui({
   },
   themes,
   tokens,
-  media: {
+  media: createMedia({
     xs: { maxWidth: 660 },
     sm: { maxWidth: 800 },
     md: { maxWidth: 1020 },
@@ -76,7 +77,7 @@ const config = createTamagui({
     tall: { minHeight: 820 },
     hoverNone: { hover: "none" },
     pointerCoarse: { pointer: "coarse" },
-  },
+  }),
 });
 
 export type AppConfig = typeof config;


### PR DESCRIPTION
Fixes #16 according to  https://tamagui.dev/docs/core/use-media

> @tamagui/core doesn't provide media capabilities out of the box to native apps. To enable media queries for React Native, you need to provide matchMedia implementation

