### PR TITLE
fix: safeareaview dark mode

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from "react";
 import { useColorScheme } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
 import {
   DarkTheme,
   DefaultTheme,
@@ -11,6 +10,7 @@ import { SplashScreen, Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { TamaguiProvider, Text, Theme } from "tamagui";
 
+import { MySafeAreaView } from "../components/MySafeAreaView";
 import config from "../tamagui.config";
 
 export default function Layout() {
@@ -27,21 +27,21 @@ export default function Layout() {
 
   return (
     <TamaguiProvider config={config}>
-      <SafeAreaView style={{ flex: 1 }}>
-        <Suspense fallback={<Text>Loading...</Text>}>
-          <Theme name={colorScheme}>
-            <ThemeProvider
-              value={colorScheme === "light" ? DefaultTheme : DarkTheme}
-            >
+      <Suspense fallback={<Text>Loading...</Text>}>
+        <Theme name={colorScheme}>
+          <ThemeProvider
+            value={colorScheme === "light" ? DefaultTheme : DarkTheme}
+          >
+            <MySafeAreaView>
               <Stack
                 screenOptions={{
                   headerShown: false
                 }}
               />
-            </ThemeProvider>
-          </Theme>
-        </Suspense>
-      </SafeAreaView>
+            </MySafeAreaView>
+          </ThemeProvider>
+        </Theme>
+      </Suspense>
       <StatusBar
         style="light"
         backgroundColor="#000000"

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -42,10 +42,6 @@ export default function Layout() {
           </ThemeProvider>
         </Theme>
       </Suspense>
-      <StatusBar
-        style="light"
-        backgroundColor="#000000"
-      />
     </TamaguiProvider>
   );
 }

--- a/components/MySafeAreaView.ts
+++ b/components/MySafeAreaView.ts
@@ -4,5 +4,5 @@ import { styled } from "tamagui";
 export const MySafeAreaView = styled(SafeAreaView, {
   name: "MySafeAreaView",
   flex: 1,
-  backgroundColor: "$backgroundStrong",
+  backgroundColor: "$backgroundStrong"
 });

--- a/components/MySafeAreaView.ts
+++ b/components/MySafeAreaView.ts
@@ -1,0 +1,8 @@
+import { SafeAreaView } from "react-native-safe-area-context";
+import { styled } from "tamagui";
+
+export const MySafeAreaView = styled(SafeAreaView, {
+  name: "MySafeAreaView",
+  flex: 1,
+  backgroundColor: "$backgroundStrong",
+});


### PR DESCRIPTION
Making SafeAreaView dark mode compatible. I didn't know if Suspense needs to be moved within MySafeAreaView? I can update the PR if it needs to.

I've also removed the StatusBar so that it works with dark mode.

Before:
![IMG_3692](https://github.com/ivopr/tamagui-expo/assets/58880442/e11ff1c3-fb65-4175-9997-5592aa970c43)
![IMG_3691](https://github.com/ivopr/tamagui-expo/assets/58880442/7767dca2-1884-47af-be6c-d88718c540f4)

After:
![IMG_3688](https://github.com/ivopr/tamagui-expo/assets/58880442/108d7567-a792-4993-a856-06951388a287)
![IMG_3687](https://github.com/ivopr/tamagui-expo/assets/58880442/0966f36d-6740-457f-aaa6-2a3b6ed199b9)
